### PR TITLE
Discard Python 2.5 in Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - 2.5
   - 2.6
   - 2.7
   - 3.3


### PR DESCRIPTION
The Python 2.5 has been removed from Travis CI. It was noticed in https://github.com/travis-ci/travis-ci/issues/1668.